### PR TITLE
BugFix - Preserve whitespaces when loading xml files

### DIFF
--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/DummyTypes/SubDummyClass.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/DummyTypes/SubDummyClass.cs
@@ -1,6 +1,9 @@
 ﻿
 namespace XmlDocExtractionLib.Tests.DummyTypes
 {
+    /// <summary>
+    /// docs with <see langword="false"/> <see langword="true"/>.
+    /// </summary>
     public class SubDummyClass : AbstractDummyClass
     {
         /// <summary>

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/InheritdocResolverTests.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/InheritdocResolverTests.cs
@@ -37,7 +37,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfBaseMember = new XElement(baseMemberXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfBaseMember.XPathEvaluate("/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfBaseMember.XPathEvaluate("/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -58,7 +58,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfBaseMember = new XElement(baseMemberXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfBaseMember.XPathEvaluate("/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfBaseMember.XPathEvaluate("/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -79,7 +79,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfMemberFromWhichToInherit = new XElement(memberFromWhichToInheritXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfMemberFromWhichToInherit.XPathEvaluate("/summary/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfMemberFromWhichToInherit.XPathEvaluate("/summary/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -100,7 +100,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfMemberFromWhichToInherit = new XElement(memberFromWhichToInheritXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfMemberFromWhichToInherit.XPathEvaluate("/param/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfMemberFromWhichToInherit.XPathEvaluate("/param/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -117,7 +117,7 @@ namespace XmlDocExtractionLib.Tests
             xmlExtractionContext.TryGetMemberXmlDocsFromMember(testedMember, out var memberXml);
 
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().Remove();
+            expectedResolvedMember.Descendants("inheritdoc").Single().RemoveElementWithNextWhitespace();
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -138,7 +138,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfMemberFromWhichToInherit = new XElement(memberFromWhichToInheritXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfMemberFromWhichToInherit.XPathEvaluate("/summary/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfMemberFromWhichToInherit.XPathEvaluate("/summary/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -159,7 +159,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfMemberFromWhichToInherit = new XElement(memberFromWhichToInheritXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfMemberFromWhichToInherit.XPathEvaluate("/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfMemberFromWhichToInherit.XPathEvaluate("/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -180,7 +180,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfMemberFromWhichToInherit = new XElement(memberFromWhichToInheritXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfMemberFromWhichToInherit.XPathEvaluate("/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfMemberFromWhichToInherit.XPathEvaluate("/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -197,7 +197,7 @@ namespace XmlDocExtractionLib.Tests
             xmlExtractionContext.TryGetMemberXmlDocsFromMember(testedMember, out var memberXml);
 
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().Remove();
+            expectedResolvedMember.Descendants("inheritdoc").Single().RemoveElementWithNextWhitespace();
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -214,7 +214,7 @@ namespace XmlDocExtractionLib.Tests
             xmlExtractionContext.TryGetMemberXmlDocsFromMember(testedMember, out var memberXml);
 
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().Remove();
+            expectedResolvedMember.Descendants("inheritdoc").Single().RemoveElementWithNextWhitespace();
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -231,7 +231,7 @@ namespace XmlDocExtractionLib.Tests
             xmlExtractionContext.TryGetMemberXmlDocsFromMember(testedMember, out var memberXml);
 
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().Remove();
+            expectedResolvedMember.Descendants("inheritdoc").Single().RemoveElementWithNextWhitespace();
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);
@@ -252,7 +252,7 @@ namespace XmlDocExtractionLib.Tests
 
             var copyOfBaseMember = new XElement(baseMemberXml);
             var expectedResolvedMember = new XElement(memberXml);
-            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceWith(copyOfBaseMember.XPathEvaluate("/node()"));
+            expectedResolvedMember.Descendants("inheritdoc").Single().ReplaceElementAndRemovePrevAndNextWhitespace(copyOfBaseMember.XPathEvaluate("/node()"));
 
             // Act
             var actualResolvedMember = InheritdocResolver.ResolveInheritDocumentation(memberXml, xmlExtractionContext, testedMember);

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/MemberIdentifierExtractionExtensionsTests.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/MemberIdentifierExtractionExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace XmlDocExtractionLib.Tests
             bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static ;
 
             var xmlDocumentationFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-            var xmlDocumentation = XDocument.Load(xmlDocumentationFile);
+            var xmlDocumentation = XDocument.Load(xmlDocumentationFile, LoadOptions.PreserveWhitespace);
             identifiersToSummary = xmlDocumentation.Descendants("members")
                                                    .Single()
                                                    .Elements("member")

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlDocsExtractionExtensionsTests.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlDocsExtractionExtensionsTests.cs
@@ -24,12 +24,12 @@ namespace XmlDocExtractionLib.Tests
             xmlExtractionContext.AddAssembly(testAssembly, testAssemblyXmlPath);
             xmlExtractionContext.AddAssembly(libAssembly, libAssemblyXmlPath);
 
-            var testXmlDocumentation = XDocument.Load(testAssemblyXmlPath);
+            var testXmlDocumentation = XDocument.Load(testAssemblyXmlPath, LoadOptions.PreserveWhitespace);
             var testXmlMembers = testXmlDocumentation.Descendants("members")
                                                      .Single()
                                                      .Elements("member");
 
-            var libXmlDocumentation = XDocument.Load(libAssemblyXmlPath);
+            var libXmlDocumentation = XDocument.Load(libAssemblyXmlPath, LoadOptions.PreserveWhitespace);
             var libXmlMembers = libXmlDocumentation.Descendants("members")
                                                    .Single()
                                                    .Elements("member");
@@ -110,6 +110,26 @@ namespace XmlDocExtractionLib.Tests
 
             // Assert
             Assert.IsNull(actualDocs);
+        }
+
+        [DataRow(false)]
+        [DataRow(true)]
+        [DataTestMethod]
+        public void GetXmlDocumentationOnMembers_MemberHasElementSpaceElementInDocs_WhitespaceIsPreserved(bool resolveInheritdoc)
+        {
+            // Arrange
+            MemberInfo testedMember = typeof(SubDummyClass);
+
+            var expectedString = $"<summary>{Environment.NewLine}" +
+                                 $"            docs with <see langword=\"false\"/> <see langword=\"true\"/>.{Environment.NewLine}" +
+                                 $"            </summary>";
+            var expectedDocs = XElement.Parse(expectedString, LoadOptions.PreserveWhitespace);
+
+            // Act
+            var actualDocs = testedMember.GetXmlDocumentation(xmlExtractionContext, resolveInheritdoc).Element("summary");
+
+            // Assert
+            Assert.AreEqual(expectedDocs.ToString(), actualDocs.ToString());
         }
 
         #endregion GetXmlDocumentation on Members Tests

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlDocsExtractionExtensionsTests.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlDocsExtractionExtensionsTests.cs
@@ -71,11 +71,15 @@ namespace XmlDocExtractionLib.Tests
             var expectedDocs = new XElement(xmlMembers[expectedMember.GetMemberIdentifier()]);
             expectedDocs.Attribute("name")!.Value = testedMember.GetMemberIdentifier();
 
+            // This is needed since the removal of trailing white spaces
+            // comes after element and not before element.
+            var expectedDocsString = expectedDocs.ToString().Replace("</member>", "    </member>");
+
             // Act
             var actualDocs = testedMember.GetXmlDocumentation(xmlExtractionContext, resolveInheritdoc);
 
             // Assert
-            Assert.AreEqual(expectedDocs.ToString(), actualDocs.ToString());
+            Assert.AreEqual(expectedDocsString, actualDocs.ToString());
         }
 
         [DataRow(false)]
@@ -90,11 +94,15 @@ namespace XmlDocExtractionLib.Tests
             var expectedDocs = new XElement(xmlMembers[expectedMember.GetMemberIdentifier()]);
             expectedDocs.Attribute("name")!.Value = testedMember.GetMemberIdentifier();
 
+            // This is needed since the removal of trailing white spaces
+            // comes after element and not before element.
+            var expectedDocsString = expectedDocs.ToString().Replace("</member>", "    </member>");
+
             // Act
             var actualDocs = testedMember.GetXmlDocumentation(xmlExtractionContext, resolveInheritdoc);
 
             // Assert
-            Assert.AreEqual(expectedDocs.ToString(), actualDocs.ToString());
+            Assert.AreEqual(expectedDocsString, actualDocs.ToString());
         }
 
         [DataRow(false)]
@@ -168,11 +176,15 @@ namespace XmlDocExtractionLib.Tests
             var expectedDocs = new XElement(xmlMembers[testedEnumType.GetEnumValueNameIdentifier(valueWithExpectedDocs)]);
             expectedDocs.Attribute("name")!.Value = testedEnumType.GetEnumValueNameIdentifier((int)DummyEnum2.ValueWithDuplicateDocs);
 
+            // This is needed since the removal of trailing white spaces
+            // comes after element and not before element.
+            var expectedDocsString = expectedDocs.ToString().Replace("</member>", "    </member>");
+
             // Act
             var actualDocs = testedEnumType.GetEnumValueXmlDocumentation((int)DummyEnum2.ValueWithDuplicateDocs, xmlExtractionContext, resolveInheritdoc);
 
             // Assert
-            Assert.AreEqual(expectedDocs.ToString(), actualDocs.ToString());
+            Assert.AreEqual(expectedDocsString, actualDocs.ToString());
         }
 
         [DataRow(false)]

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlExtractionContextTests.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlExtractionContextTests.cs
@@ -32,12 +32,12 @@ namespace XmlDocExtractionLib.Tests
             libAssembly = typeof(XmlExtractionContext).Assembly;
             libAssemblyXmlPath = $"{libAssembly.GetName().Name!}.xml";
 
-            var testXmlDocumentation = XDocument.Load(testAssemblyXmlPath);
+            var testXmlDocumentation = XDocument.Load(testAssemblyXmlPath, LoadOptions.PreserveWhitespace);
             var testXmlMembers = testXmlDocumentation.Descendants("members")
                                                      .Single()
                                                      .Elements("member");
 
-            var libXmlDocumentation = XDocument.Load(libAssemblyXmlPath);
+            var libXmlDocumentation = XDocument.Load(libAssemblyXmlPath, LoadOptions.PreserveWhitespace);
             var libXmlMembers = libXmlDocumentation.Descendants("members")
                                                    .Single()
                                                    .Elements("member");

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/InheritdocResolver.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/InheritdocResolver.cs
@@ -91,21 +91,21 @@ namespace XmlDocExtractionLib
                         // Therefore, if we got here, we are not in the first two levels
                         // of the xml member documentation and we do not have the path attribute
                         // so we just remove this inheritdoc.
-                        inheritdocNode.Remove();
+                        inheritdocNode.RemoveElementWithNextWhitespace();
                     }
                     else
                     {
                         pathValue ??= inheritdocNode.GetXPathFromMember();
 
                         var xpathEvaluation = resolveInheritDocumentation.XPathEvaluate(pathValue);
-                        inheritdocNode.ReplaceWith(xpathEvaluation);
+                        inheritdocNode.ReplaceElementAndRemovePrevAndNextWhitespace(xpathEvaluation);
                     }
                 }
                 else
                 {
                     // Could not resolve inheritdoc so just
                     // remove it.
-                    inheritdocNode.Remove();
+                    inheritdocNode.RemoveElementWithNextWhitespace();
                 }
             }
 

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlDocExtractionLib.csproj
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlDocExtractionLib.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>yoaverez</Authors>
     <Description>A package for extracting xml documentation from C# types and members.</Description>
     <RepositoryUrl>https://github.com/yoaverez/XmlDocExtractionLib</RepositoryUrl>
     <PackageTags>doc;xml;documentation;comment;comments;xmldoc</PackageTags>
     <Copyright>Copyright (c) 2025 yoaverez</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Core library functionality</PackageReleaseNotes>
+    <PackageReleaseNotes>Preserve white spaces when loading xmls</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlDocsExtractionExtensions.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlDocsExtractionExtensions.cs
@@ -140,7 +140,7 @@ namespace XmlDocExtractionLib
                 if (elementsWithNoIdentifier.Contains(elementName))
                 {
                     if (seenSingleElements.Contains(elementName))
-                        element.Remove();
+                        element.RemoveElementWithNextWhitespace();
                     else
                         seenSingleElements.Add(elementName);
                 }
@@ -152,7 +152,7 @@ namespace XmlDocExtractionLib
                     if(seenMultipleElements.TryGetValue(elementName, out var attributesValues))
                     {
                         if (attributesValues.Contains(attribute))
-                            element.Remove();
+                            element.RemoveElementWithNextWhitespace();
                         else
                             attributesValues.Add(attribute);
                     }

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlExtractionContext.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlExtractionContext.cs
@@ -112,7 +112,7 @@ namespace XmlDocExtractionLib
         /// <param name="pathToXmlDocumentation">The path to the xml documentation file to load.</param>
         private void LoadXml(string pathToXmlDocumentation)
         {
-            var xmlDocumentation = XDocument.Load(pathToXmlDocumentation);
+            var xmlDocumentation = XDocument.Load(pathToXmlDocumentation, LoadOptions.PreserveWhitespace);
             var xmlMembers = xmlDocumentation.Descendants("members")
                                              .Single()
                                              .Elements("member");

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlUtils.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlUtils.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace XmlDocExtractionLib
+{
+    /// <summary>
+    /// Extensions for xml nodes and elements.
+    /// </summary>
+    internal static class XmlUtils
+    {
+        /// <summary>
+        /// Remove the given <paramref name="element"/> from it parent and also
+        /// remove the next whitespace afterwards.
+        /// </summary>
+        /// <param name="element">The element to remove.</param>
+        public static void RemoveElementWithNextWhitespace(this XElement element)
+        {
+            var nextNode = element.NodesAfterSelf().FirstOrDefault();
+            element.Remove();
+            if(nextNode != null)
+            {
+                if(nextNode is XText textNode)
+                {
+                    textNode.Value = textNode.Value.TrimStart();
+                    if(string.IsNullOrEmpty(textNode.Value))
+                        textNode.Remove();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Replace the given <paramref name="element"/>
+        /// with the given <paramref name="xpathEvaluation"/>
+        /// after trimming the whitespace from the <paramref name="xpathEvaluation"/>.
+        /// </summary>
+        /// <param name="element">The element to replace.</param>
+        /// <param name="xpathEvaluation">The replacement of the <paramref name="element"/>.</param>
+        public static void ReplaceElementAndRemovePrevAndNextWhitespace(this XElement element, object xpathEvaluation)
+        {
+            var nodes = (xpathEvaluation as IEnumerable)?.Cast<XNode>();
+            if (nodes is null)
+            {
+                element.ReplaceWith(xpathEvaluation);
+            }
+            else
+            {
+                if (nodes.Any())
+                {
+                    if(nodes.First() is XText firstNodeText)
+                        firstNodeText.Value = firstNodeText.Value.TrimStart();
+
+                    if (nodes.Last() is XText lastNodeText)
+                        lastNodeText.Value = lastNodeText.Value.TrimEnd();
+
+                    var noneEmptyNodes = nodes.Where(node =>
+                    {
+                        return !(node is XText textNode) || string.IsNullOrEmpty(textNode.Value);
+                    });
+
+                    if (noneEmptyNodes.Any())
+                        element.ReplaceWith(noneEmptyNodes);
+                }
+                else
+                {
+                    element.RemoveElementWithNextWhitespace();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When there are two xml elements in the xml file that are separated by a space, the space is remove if the xml is loaded without the preserving white space option.

Also remove white spaces after element removal and before and after element replacement.  