### PR TITLE
BugFix - ReplaceElementAndRemovePrevAndNextWhitespace replace condition was wrong

### DIFF
--- a/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlUtilsTests.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib.Tests/XmlUtilsTests.cs
@@ -1,0 +1,184 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Xml.Linq;
+
+namespace XmlDocExtractionLib.Tests
+{
+    [TestClass]
+    public class XmlUtilsTests
+    {
+        #region RemoveElementWithNextWhitespace Tests
+
+        [TestMethod]
+        public void RemoveElementWithNextWhitespace_NextNodeIsATextNodeWithOnlyWhitespaces_BothElementAndTextNodeAreRemoved()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <remove/> \n \r\n<anotherElement /></member>";
+            var expectedXmlStr = $"<member> hey there <anotherElement /></member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("remove");
+
+            // Act
+            testedElement.RemoveElementWithNextWhitespace();
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void RemoveElementWithNextWhitespace_NextNodeIsATextNodeWithSomeWhitespaces_ElementIsRemovedAndTextNodeIsTrimmedFromStart()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <remove/> \n text\r\n<anotherElement /></member>";
+            var expectedXmlStr = $"<member> hey there text\r\n<anotherElement /></member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("remove");
+
+            // Act
+            testedElement.RemoveElementWithNextWhitespace();
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void RemoveElementWithNextWhitespace_NextNodeIsANotATextNode_ElementIsRemovedAndNextElementIsUnChanged()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <remove/><anotherElement /></member>";
+            var expectedXmlStr = $"<member> hey there <anotherElement /></member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("remove");
+
+            // Act
+            testedElement.RemoveElementWithNextWhitespace();
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void RemoveElementWithNextWhitespace_NextNodeIsNull_InvalidOperationExceptionIsThrown()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <remove/><anotherElement /></member>";
+            var expectedXmlStr = $"";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml;
+
+            // Act + Assert
+            Assert.ThrowsException<InvalidOperationException>(testedElement.RemoveElementWithNextWhitespace);
+        }
+
+        #endregion RemoveElementWithNextWhitespace Tests
+
+        #region ReplaceElementAndRemovePrevAndNextWhitespace Tests
+
+        [TestMethod]
+        public void ReplaceElementAndRemovePrevAndNextWhitespace_XPathEvaluationIsASingleTextNode_TrimWhitespacesFromTextNode()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <replace/> </member>";
+            var expectedXmlStr = $"<member> hey there replacement string </member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("replace");
+
+            // Act
+            testedElement.ReplaceElementAndRemovePrevAndNextWhitespace(new List<XNode> { new XText("    replacement string ") });
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void ReplaceElementAndRemovePrevAndNextWhitespace_XPathEvaluationHasMultipleTextNodes_TrimWhitespacesFromStartOfFirstTextNodeAndFromTheEndOfTheLastNode()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <replace/> </member>";
+            var expectedXmlStr = $"<member> hey there replacement string  hello </member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("replace");
+
+            // Act
+            testedElement.ReplaceElementAndRemovePrevAndNextWhitespace(new List<XNode> { new XText("    replacement string "), new XText(" hello ") });
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void ReplaceElementAndRemovePrevAndNextWhitespace_XPathEvaluationIsASingleElementNodes_DoesNotTrimWhitespacesAndElementIsReplacedCorrectly()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <replace/> </member>";
+            var expectedXmlStr = $"<member> hey there <newElement /> hello </member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("replace");
+
+            // Act
+            testedElement.ReplaceElementAndRemovePrevAndNextWhitespace(new List<XNode> { new XElement("newElement"), new XText(" hello ") });
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void ReplaceElementAndRemovePrevAndNextWhitespace_XPathEvaluationIsASingleTextNodeWithOnlyWhitespaces_ElementIsRemovedWithTrailingWhitespaces()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <replace/> </member>";
+            var expectedXmlStr = $"<member> hey there </member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("replace");
+
+            // Act
+            testedElement.ReplaceElementAndRemovePrevAndNextWhitespace(new List<XNode> { new XText("  \n \r\n") });
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void ReplaceElementAndRemovePrevAndNextWhitespace_XPathEvaluationIsEmptyListOfXnodes_ElementIsRemovedWithTrailingWhitespaces()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <replace/> </member>";
+            var expectedXmlStr = $"<member> hey there </member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("replace");
+
+            // Act
+            testedElement.ReplaceElementAndRemovePrevAndNextWhitespace(new List<XNode> { });
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        [TestMethod]
+        public void ReplaceElementAndRemovePrevAndNextWhitespace_XPathEvaluationIsNotAListOfXnodes_ElementIsReplacedWithoutRemovingTrailingWhitespaces()
+        {
+            // Arrange
+            var originalXmlStr = $"<member> hey there <replace/> </member>";
+            var expectedXmlStr = $"<member> hey there  hello  </member>";
+            var originalXml = XElement.Parse(originalXmlStr, LoadOptions.PreserveWhitespace);
+            var testedXml = new XElement(originalXml);
+            var testedElement = testedXml.Element("replace");
+
+            // Act
+            testedElement.ReplaceElementAndRemovePrevAndNextWhitespace(" hello ");
+
+            // Assert
+            Assert.AreEqual(expectedXmlStr, testedXml.ToString());
+        }
+
+        #endregion ReplaceElementAndRemovePrevAndNextWhitespace Tests
+    }
+}

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlDocExtractionLib.csproj
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlDocExtractionLib.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>yoaverez</Authors>
     <Description>A package for extracting xml documentation from C# types and members.</Description>
     <RepositoryUrl>https://github.com/yoaverez/XmlDocExtractionLib</RepositoryUrl>
     <PackageTags>doc;xml;documentation;comment;comments;xmldoc</PackageTags>
     <Copyright>Copyright (c) 2025 yoaverez</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Preserve white spaces when loading xmls</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix xml element replacement method</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlUtils.cs
+++ b/src/XmlDocExtractionLib/XmlDocExtractionLib/XmlUtils.cs
@@ -18,12 +18,12 @@ namespace XmlDocExtractionLib
         {
             var nextNode = element.NodesAfterSelf().FirstOrDefault();
             element.Remove();
-            if(nextNode != null)
+            if (nextNode != null)
             {
-                if(nextNode is XText textNode)
+                if (nextNode is XText textNode)
                 {
                     textNode.Value = textNode.Value.TrimStart();
-                    if(string.IsNullOrEmpty(textNode.Value))
+                    if (string.IsNullOrEmpty(textNode.Value))
                         textNode.Remove();
                 }
             }
@@ -38,16 +38,16 @@ namespace XmlDocExtractionLib
         /// <param name="xpathEvaluation">The replacement of the <paramref name="element"/>.</param>
         public static void ReplaceElementAndRemovePrevAndNextWhitespace(this XElement element, object xpathEvaluation)
         {
-            var nodes = (xpathEvaluation as IEnumerable)?.Cast<XNode>();
-            if (nodes is null)
+            if (xpathEvaluation is string || xpathEvaluation is not IEnumerable)
             {
                 element.ReplaceWith(xpathEvaluation);
             }
             else
             {
+                var nodes = (xpathEvaluation as IEnumerable)?.Cast<XNode>();
                 if (nodes.Any())
                 {
-                    if(nodes.First() is XText firstNodeText)
+                    if (nodes.First() is XText firstNodeText)
                         firstNodeText.Value = firstNodeText.Value.TrimStart();
 
                     if (nodes.Last() is XText lastNodeText)
@@ -55,11 +55,14 @@ namespace XmlDocExtractionLib
 
                     var noneEmptyNodes = nodes.Where(node =>
                     {
-                        return !(node is XText textNode) || string.IsNullOrEmpty(textNode.Value);
+                        // True if the node is not a text node or if the text node is not empty.
+                        return !(node is XText textNode) || !string.IsNullOrEmpty(textNode.Value);
                     });
 
                     if (noneEmptyNodes.Any())
                         element.ReplaceWith(noneEmptyNodes);
+                    else
+                        element.RemoveElementWithNextWhitespace();
                 }
                 else
                 {


### PR DESCRIPTION
There were two bugs:
1. condition for replacement was wrong.
2. The xpathEvaluation can be a string which is also and enumerable.